### PR TITLE
Add contributors section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+# 📝 Pull Request Template
+
+## 📄 Description
+
+Provide a clear and concise description of what this pull request does.  
+Include any background context and the motivation behind this change.
+
+> Example:  
+> This PR adds a new feature that allows users to upload profile images.  
+> It also refactors the user controller for better maintainability.
+---
+
+## 🔗 Related Issues
+
+Link any related issues using the format below.  
+This will **auto-close** the issue when merged:
+
+> Fixes #<issue_number>
+---
+
+## 🖼️ Screenshots (if applicable)
+
+If your changes include UI updates or visual changes, add screenshots or GIFs here.
+
+---
+
+## 🧩 Type of Change
+
+Select the type of change your PR introduces (check all that apply):
+
+- [ ] 🐛 Bug Fix  
+- [ ] ✨ New Feature  
+- [ ] ⚡ Enhancement / Optimization  
+- [ ] 🧰 Refactoring  
+- [ ] 🧾 Documentation Update  
+- [ ] 🔧 Other (please specify): ____________
+
+---
+
+## ✅ Checklist
+
+Before submitting your PR, please confirm the following:
+
+- [ ] I have performed a self-review of my code.  
+- [ ] I have commented my code, particularly in hard-to-understand areas.  
+- [ ] I have added or updated relevant documentation.  
+- [ ] My changes do not break any existing functionality.  
+- [ ] I have tested my changes locally and they work as expected.  
+- [ ] I have linked all relevant issues (if any).
+
+---
+
+## 💬 Additional Notes (Optional)
+
+Add any other information, context, or comments that reviewers might find useful.

--- a/README.md
+++ b/README.md
@@ -353,6 +353,21 @@ We welcome contributions! Please follow these steps:
 - Update documentation as needed
 - Ensure all tests pass before submitting PR
 
+---
+
+
+## ✨ Contributors
+
+#### Thanks to all the wonderful contributors 💖
+
+<a href="https://github.com/koustavx08/synthamint-platform/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=koustavx08/synthamint-platform" />
+</a>
+
+#### See full list of contributor contribution [Contribution Graph](https://github.com/koustavx08/synthamint-platform/graphs/contributors)  
+
+---
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Description
This PR adds a Contributors section to the README.md to recognize and showcase all contributors, making the repository more welcoming for new contributors.

Current Problem
The README.md currently lacks a Contributors section to recognize contributors and guide new ones.

Proposed Solution
Add a Contributors section at the end of README.md
Include an auto-generated contributor badge via [contrib.rocks](https://contrib.rocks/)
Update Table of Contents to include this new section
Keep all existing content intact and improve formatting where necessary

Benefits
Recognizes contributors and shows appreciation
Makes the repository more welcoming for new contributors
Improves documentation readability and structure

Close issue #13 